### PR TITLE
Use class identifier to get selected payment method element.

### DIFF
--- a/assets/js/stripe.js
+++ b/assets/js/stripe.js
@@ -830,7 +830,7 @@ jQuery( function( $ ) {
 		 */
 		onError: function( e, result ) {
 			var message = result.error.message;
-			var selectedMethodElement = wc_stripe_form.getSelectedPaymentElement().closest( 'li' );
+			var selectedMethodElement = wc_stripe_form.getSelectedPaymentElement().closest( '.wc_payment_method' );
 			var savedTokens = selectedMethodElement.find( '.woocommerce-SavedPaymentMethods-tokenInput' );
 			var errorContainer;
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 7.8.0 - xxxx-xx-xx =
+* Fix - Resolved an issue with Stripe errors not being displayed on the checkout page for stores using custom payment method elements.
 * Fix - Resolved a PHP fatal error occurring on stores that removed `WC_Email_Failed_Order` from the list of WC email classes while attempting to send the failed order email.
 * Fix - Prevent incorrect totals displayed in Google Pay and Apple Pay when purchasing a virtual sychronised subscription from the product page.
 * Fix - Hide the Google Pay and Apple Pay buttons on variable product pages, if the selected variation is not supported by Payment Request buttons.

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 7.8.0 - xxxx-xx-xx =
+* Fix - Resolved an issue with Stripe errors not being displayed on the checkout page for stores using custom payment method elements.
 * Fix - Resolved a PHP fatal error occurring on stores that removed `WC_Email_Failed_Order` from the list of WC email classes while attempting to send the failed order email.
 * Fix - Prevent incorrect totals displayed in Google Pay and Apple Pay when purchasing a virtual sychronised subscription from the product page.
 * Fix - Hide the Google Pay and Apple Pay buttons on variable product pages, if the selected variation is not supported by Payment Request buttons.


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Using custom elements in checkout payment method section will stop Stripe errors from showing, we learned (cxl.com).

This PR proposes to use class identifier `.wc_payment_method` instead of element `li` to query for payment method element.


